### PR TITLE
Add makefile targets and documentation required to enable crosscompilation to raspberry pi boards

### DIFF
--- a/CROSSCOMPILE.md
+++ b/CROSSCOMPILE.md
@@ -1,11 +1,12 @@
-# Crosscompilation for ARMHF
+# Crosscompilation for ARMHF/ARM64
 
 As armhf boards (like the raspberry pi) are becoming more and more common, 
-cheaper and more powerful, using `fireguard` on an armhf board is becoming
-more conveniente. This document explains briefly the changes necessary
+cheaper and more powerful, using `fireguard` on an armhf/arm64 board is becoming
+more convenient. This document explains briefly the changes necessary
 for crosscompiling the project on Debian/Ubuntu (the developer's platform
 of choice) for the armhf architecture (that supports RaspberryPi versions 2
-to 4 inclusive and many other boards (like the ones from hardkernel)).
+to 3 inclusive and many other boards (like the ones from hardkernel)) and the
+arm64 architecture like the Raspberry Pi 4 models.
 
 # Local configuration
 
@@ -20,7 +21,8 @@ user.
 Run the command
 
 ```
-rustup target add armv7-unknown-linux-gnueabihf
+rustup target add armv7-unknown-linux-gnueabihf # raspberry < 4
+rustup target add aarch64-unknown-linux-gnu # raspberry >= 4
 ```
 
 to download the required Rust components for the target architecture
@@ -33,6 +35,9 @@ there) and add
 ```
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
 ```
 
 so that the `cargo` command knows what linker to call
@@ -43,6 +48,7 @@ Run the command
 
 ```
 dpkg --add-architecture armhf
+dpkg --add-architecture arm64
 ```
 
 and update the list of packages with
@@ -60,6 +66,7 @@ Run the command
 
 ```
 apt install crossbuild-essential-armhf
+apt install crossbuild-essential-arm64
 ```
 
 this metapackage will _not_ be available unless you add the architecture
@@ -71,11 +78,13 @@ To test the crosscompilation setup you should be able to use the provided
 `Makefile` and invoke
 
 ```
-make raspberry
+make raspberry_<arch>
 ```
 
-to build the binaries in `release` mode. The `raspberry_debug` make target is
+to build the binaries in `release` mode. The `raspberry_<arch>_debug` make target is
 also provided if you need debugging symbols in your binaries.
+
+`<arch>` is the name of the architecture you are targeting.
 
 
 # Binaries
@@ -86,6 +95,7 @@ architecture, in this case:
 
 ```
 target/armv7-unknown-linux-gnueabihf/release/fireguard
+target/aarch64-unknown-linux-gnu/release/fireguard
 ```
 
 or `debug` if you built with the debug symbols enabled.

--- a/CROSSCOMPILE.md
+++ b/CROSSCOMPILE.md
@@ -1,0 +1,91 @@
+# Crosscompilation for ARMHF
+
+As armhf boards (like the raspberry pi) are becoming more and more common, 
+cheaper and more powerful, using `fireguard` on an armhf board is becoming
+more conveniente. This document explains briefly the changes necessary
+for crosscompiling the project on Debian/Ubuntu (the developer's platform
+of choice) for the armhf architecture (that supports RaspberryPi versions 2
+to 4 inclusive and many other boards (like the ones from hardkernel)).
+
+# Local configuration
+
+This guide assumes you are using [rustup](https://rustup.rs/) for managing
+the toolchains and that you are running a fairly modern Debian or Ubuntu
+host on `amd64` architecture. Cargo and rust commands do not require root,
+`dpkg` and `apt` ones are to be invoked via `sudo` (recommended) or the root
+user.
+
+## 1: Add the architecture to rustup
+
+Run the command
+
+```
+rustup target add armv7-unknown-linux-gnueabihf
+```
+
+to download the required Rust components for the target architecture
+
+## 2: Configure cargo to support that target
+
+Edit the file in `~/.cargo/config` (create it if it's not already
+there) and add
+
+```
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+```
+
+so that the `cargo` command knows what linker to call
+
+## 3: Add the target architecture to your host
+
+Run the command
+
+```
+dpkg --add-architecture armhf
+```
+
+and update the list of packages with
+
+```
+apt update
+```
+
+## 4: Install the metapackage for the target architecture
+
+Debian and Ubuntu luckily provide some `crossbuild-*`  metapackages that pull
+all the required packages to support cargo in its job.
+
+Run the command
+
+```
+apt install crossbuild-essential-armhf
+```
+
+this metapackage will _not_ be available unless you add the architecture
+as per the step above.
+
+## 5: You should now be all set
+
+To test the crosscompilation setup you should be able to use the provided
+`Makefile` and invoke
+
+```
+make raspberry
+```
+
+to build the binaries in `release` mode. The `raspberry_debug` make target is
+also provided if you need debugging symbols in your binaries.
+
+
+# Binaries
+
+You should be able to find the binaries for the target architecture in
+the `target` directory as usual, under a directory named like the target 
+architecture, in this case:
+
+```
+target/armv7-unknown-linux-gnueabihf/release/fireguard
+```
+
+or `debug` if you built with the debug symbols enabled.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 all: debug
 
+cross: raspberry
+
 debug:
 	cargo build
 
 release:
 	cargo build --release
+
+raspberry_debug:
+	cargo build --target=armv7-unknown-linux-gnueabihf
+
+raspberry:
+	cargo build --release --target=armv7-unknown-linux-gnueabihf

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
 all: debug
 
-cross: raspberry
-
 debug:
 	cargo build
 
 release:
 	cargo build --release
 
-raspberry_debug:
+raspberry_armhf_debug:
 	cargo build --target=armv7-unknown-linux-gnueabihf
 
-raspberry:
+raspberry_armhf:
 	cargo build --release --target=armv7-unknown-linux-gnueabihf
+
+raspberry_aarch64_debug:
+	cargo build --target=aarch64-unknown-linux-gnu
+
+raspberry_aarch64:
+	cargo build --release --target=aarch64-unknown-linux-gnu 


### PR DESCRIPTION
This change adds documentation in the `CROSSCOMPILE.md` file for setting up an Ubuntu/Debian host for crosscompiling
fireguard for a raspberry model 2/3/4 board. 