### PR TITLE
Fix wireguard package installation in Docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # 📰 Changelog 📰
 
+- [Version 0.0.5](#version-0.0.5)
 - [Version 0.0.4](#version-0.0.4)
 - [Version 0.0.3](#version-0.0.3)
 - [Version 0.0.2](#version-0.0.2)
 - [Version 0.0.1](#version-0.0.1)
+
+## Version 0.0.5
+* 161eb90 Update changelog for v0.0.5
+* fd05d6a Release version 0.0.5
+* 39d3c99 Add docker multi arch build directives to Makefile
+* 42ffe8e Fix #12. Move package installation to Fireguard startup to let it happen on the actual host and not during docker buildx, where apt causes many failures inside docker qemu.
 
 ## Version 0.0.4
 * 2c55318 Release version 0.0.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,14 @@ Contributions are welcome and we will happily review them.
 ## How do I release a new version?
 To release a new version, update the crate version in `Cargo.toml`, create a new git tag and push the tags:
 ```sh
-❯❯❯ VERSION=0.1.0
-❯❯❯ vim Cargo.toml
-❯❯❯ CHANGELOG=$(git log $(git describe --tags --abbrev=0)..HEAD --oneline)
-❯❯❯ # add ${CHANGELOG} to CHANGELOG.md
-❯❯❯ git commit -a -m "Release version $VERSION"
-❯❯❯ git tag v$VERSION
-❯❯❯ git push --tags
+❯❯❯ vim Cargo.toml                      # Update the minor or major version number
+❯❯❯ git add Cargo.toml
+❯❯❯ git commit -a -m "Release v0.X.0"   # Change with the new version
+❯❯❯ cargo build                         # Rebuild to allow the tag version to be automatically guessed
+❯❯❯ make tag                            # When prompted in vim, add a commit message like
+                                        # "Update changelog for v0.X.0"
+❯❯❯ git push                            # Push the repo
+❯❯❯ git push --tagd                     # Push the tags
 ```
 
 This will kick a special CI mode on [Travis](https://travis-ci.org/github/blackmesalab/fireguard) 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ futures-util = "0.3.9"
 ipnet = "2.3"
 lazy_static = "1.4"
 log = "0.4"
+nix = "0.19"
 openssl = { version = '0.10', features = ["vendored"] }
 parking_lot = { version = "0.11", features = ["deadlock_detection"] }
 pretty_env_logger = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fireguard"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Bigo <bigo@crisidev.org>"]
 edition = "2018"
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,18 @@ raspberry_aarch64_debug:
 raspberry_aarch64:
 	cargo build --release --target=aarch64-unknown-linux-gnu 
 
+tag:
+	$(eval VERSION=$(shell target/debug/fireguard --version | sed 's#fireguard ##g'))
+	$(eval CHANGELOG=$(shell git log $(shell git describe --tags --abbrev=0)..HEAD --oneline))
+	@echo The changelog from the previous tag to $(VERSION) is:$(CHANGELOG)
+	@echo "######################### Start $(VERSION) changelog ###################" >> CHANGELOG.md
+	@echo $(CHANGELOG) >> CHANGELOG.md
+	@echo "######################### End $(VERSION) changelog ###################" >> CHANGELOG.md
+	vim CHANGELOG.md
+	git add CHANGELOG.md
+	git commit CHANGELOG.md
+	git tag v$(VERSION)
+
 docker_prepare:
 	cross build --target x86_64-unknown-linux-gnu --release
 	cross build --target aarch64-unknown-linux-gnu --release
@@ -28,15 +40,18 @@ docker_prepare:
 	cp target/x86_64-unknown-linux-gnu/release/fireguard docker/linux/amd64/fireguard
 	cp target/aarch64-unknown-linux-gnu/release/fireguard docker/linux/amd64/fireguard
 	cp target/armv7-unknown-linux-musleabihf/release/fireguard docker/linux/arm/v7
-	$(eval VERSION=$(shell target/x86_64-unknown-linux-gnu/release/fireguard --version | sed 's#fireguard ##g'))
+
 docker_build: docker_prepare
+	$(eval VERSION=$(shell target/x86_64-unknown-linux-gnu/release/fireguard --version | sed 's#fireguard ##g'))
 	docker buildx create --use --name=qemu || echo "Already exist"
 	docker buildx inspect --bootstrap
 	docker buildx build --platform linux/arm64,linux/arm/v7 -t blackmesalab/fireguard:latest docker 
 	docker buildx build --platform linux/arm64,linux/arm/v7 -t blackmesalab/fireguard:$(VERSION) docker 
 	docker buildx build --load --platform linux/amd64 -t blackmesalab/fireguard:latest docker 
 	docker buildx build --load --platform linux/amd64 -t blackmesalab/fireguard:$(VERSION) docker 
+
 docker_push: docker_prepare
+	$(eval VERSION=$(shell target/x86_64-unknown-linux-gnu/release/fireguard --version | sed 's#fireguard ##g'))
 	docker buildx create --use --name=qemu || echo "Already exist"
 	docker buildx inspect --bootstrap
 	docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7 -t blackmesalab/fireguard:latest docker 

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,26 @@ raspberry_aarch64_debug:
 raspberry_aarch64:
 	cargo build --release --target=aarch64-unknown-linux-gnu 
 
-docker_build:
-	cross build --target x86_64-unknown-linux-musl --release
-	cp target/x86_64-unknown-linux-musl/release/fireguard docker/
-	$(eval VERSION=$(shell target/x86_64-unknown-linux-musl/release/fireguard --version | sed 's#fireguard ##g'))
-	docker build -t blackmesalab/fireguard:latest docker
-	docker tag blackmesalab/fireguard:latest blackmesalab/fireguard:$(VERSION)
+docker_prepare:
+	cross build --target x86_64-unknown-linux-gnu --release
+	cross build --target aarch64-unknown-linux-gnu --release
+	cross build --target armv7-unknown-linux-gnueabihf --release
+	mkdir -p docker/linux/amd64
+	mkdir -p docker/linux/arm64
+	mkdir -p docker/linux/arm/v7
+	cp target/x86_64-unknown-linux-gnu/release/fireguard docker/linux/amd64/fireguard
+	cp target/aarch64-unknown-linux-gnu/release/fireguard docker/linux/amd64/fireguard
+	cp target/armv7-unknown-linux-musleabihf/release/fireguard docker/linux/arm/v7
+	$(eval VERSION=$(shell target/x86_64-unknown-linux-gnu/release/fireguard --version | sed 's#fireguard ##g'))
+docker_build: docker_prepare
+	docker buildx create --use --name=qemu || echo "Already exist"
+	docker buildx inspect --bootstrap
+	docker buildx build --platform linux/arm64,linux/arm/v7 -t blackmesalab/fireguard:latest docker 
+	docker buildx build --platform linux/arm64,linux/arm/v7 -t blackmesalab/fireguard:$(VERSION) docker 
+	docker buildx build --load --platform linux/amd64 -t blackmesalab/fireguard:latest docker 
+	docker buildx build --load --platform linux/amd64 -t blackmesalab/fireguard:$(VERSION) docker 
+docker_push: docker_prepare
+	docker buildx create --use --name=qemu || echo "Already exist"
+	docker buildx inspect --bootstrap
+	docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7 -t blackmesalab/fireguard:latest docker 
+	docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7 -t blackmesalab/fireguard:$(VERSION) docker 

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,3 +1,3 @@
 # Test executables
-boringtun
 fireguard
+linux

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,11 @@
 # User container image
-FROM alpine:latest
-RUN mkdir -p /etc/fireguard /etc/wireguard && \
-        apk update && \
-        apk add bash iptables ca-certificates \
-        wireguard-tools dnsmasq 
+FROM debian:testing-slim
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 
-COPY fireguard /usr/bin/fireguard
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+RUN mkdir -p /etc/fireguard /etc/wireguard
+
+COPY ./$TARGETPLATFORM/fireguard /usr/bin/fireguard
 
 CMD ["/usr/bin/fireguard"]

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -1,14 +1,19 @@
 use std::process;
 
 use clap::Clap;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{bail, Result};
+use nix::sys::signal;
+use nix::unistd::Pid;
 use signal_hook::consts::signal::*;
 use signal_hook::iterator::Signals;
-use tokio::task;
+use tokio::{fs, task};
 
+use crate::cmd::peer::List;
 use crate::cmd::repo::Clone;
-use crate::cmd::wg::{Down, Render, Up};
+use crate::cmd::wg::{Down, Render, Status as WgStatus, Up};
 use crate::cmd::{Command, Fireguard};
+use crate::config::Config;
+use crate::utils::install_wireguard_kernel_module;
 
 /// Daemon - Manage Fireguard daemon
 #[derive(Clap, Debug)]
@@ -16,75 +21,148 @@ pub struct Daemon {
     /// Peer subcommands
     #[clap(subcommand)]
     pub action: Action,
+    /// Repository name
+    #[clap(short = 'r', long = "repository")]
+    pub repository: String,
 }
 
 #[derive(Clap, Debug)]
 pub enum Action {
-    /// Run the Fireguard daemon
+    /// Run Fireguard daemon. If `repository-url` is set a new clone in the `repository` folder will be
+    /// peformed. If `private-key` is set, a new render of the Wireguard configuration will be
+    /// performed. A signal handler is installer for TERM and INT with graceful shutdown. HUP for
+    /// now does nothing. The main process PID is stored in a PID file.
     Serve(Serve),
+    /// Stop the Fireguard daemon by sending a SIGTERM to its PID from the PID file.
+    Stop(Stop),
+    /// Fireguard daemon status, exposing information about the different running components and
+    /// the current configuration.
+    Status(Status),
 }
 
 impl Command for Daemon {}
 impl Daemon {
     pub async fn exec(&self, fg: &Fireguard) -> Result<()> {
         match self.action {
-            Action::Serve(ref action) => action.exec(fg).await?,
+            Action::Serve(ref action) => action.exec(fg, &self.repository).await?,
+            Action::Stop(ref action) => action.exec(fg, &self.repository).await?,
+            Action::Status(ref action) => action.exec(fg, &self.repository).await?,
         }
         Ok(())
     }
 }
 
-/// Run Fireguard daemon
+/// Run Fireguard daemon. If `repository-url` is set a new clone in the `repository` folder will be
+/// peformed. If `private-key` is set, a new render of the Wireguard configuration will be
+/// performed.
 #[derive(Clap, Debug)]
 pub struct Serve {
     /// Repository URL
-    #[clap(short = 'u', long = "repository-url")]
-    pub repository_url: String,
-    /// Repository name
-    #[clap(short = 'r', long = "repository-name")]
-    pub repository_name: String,
+    #[clap(short = 'U', long = "repository-url")]
+    pub repository_url: Option<String>,
     /// Private key
     #[clap(short = 'P', long = "private-key")]
-    pub private_key: String,
+    pub private_key: Option<String>,
     /// User name
     #[clap(short = 'u', long = "username")]
     pub username: String,
     /// Peer name
     #[clap(short = 'p', long = "peername")]
     pub peername: String,
-    /// Config file path
+    /// Wireguard config file path
     #[clap(short = 'c', long = "config-dir", default_value = "/etc/wireguard")]
     pub config_dir: String,
 }
 
 impl Command for Serve {}
 impl Serve {
-    pub async fn exec(&self, fg: &Fireguard) -> Result<()> {
-        info!("Starting Fireguard daemon in foreground");
-        let clone = Clone {};
-        clone.exec(fg, &self.repository_url).await?;
-        let render = Render {
-            username: self.username.clone(),
-            peername: self.peername.clone(),
-            private_key: self.private_key.clone(),
-            config_dir: self.config_dir.clone(),
-        };
-        render.exec(fg, &self.repository_name).await?;
-        let config = self.load_config(&self.repository_name, &fg.config_dir, &fg.config_file).await?;
-        config.write_pid_file("fireguard", process::id()).await?;
-        let up = Up {};
-        up.exec(None, &self.repository_name).await?;
-        let mut signals = Signals::new(&[SIGTERM, SIGINT]).unwrap();
-        let repository_name = self.repository_name.clone();
+    async fn handle_signals(&self, config: Config, repository: String) -> Result<()> {
+        let mut signals = Signals::new(&[SIGTERM, SIGINT])?;
         let t = task::spawn(async move {
             for sig in signals.forever() {
                 warn!("Received signal {:#?}, shutting down Fireguard", sig);
                 let down = Down {};
-                down.exec(None, &repository_name).await.unwrap_or(());
+                down.exec(None, &repository).await.unwrap_or_else(|_| error!("Unable to shut down Wireguard"));
+                config
+                    .remove_pid_file("fireguard")
+                    .await
+                    .unwrap_or_else(|_| error!("Unable to remove PID file for wireguard"));
                 return;
             }
         });
         t.await?;
         Ok(())
+    }
+
+    pub async fn exec(&self, fg: &Fireguard, repository: &str) -> Result<()> {
+        info!("Starting Fireguard daemon in foreground");
+        install_wireguard_kernel_module().await?;
+        if let Some(repo) = self.repository_url.as_ref() {
+            let clone = Clone {};
+            clone.exec(fg, repo).await?;
+        }
+        if let Some(pkey) = self.private_key.as_ref() {
+            let render = Render {
+                username: self.username.clone(),
+                peername: self.peername.clone(),
+                private_key: pkey.clone(),
+                config_dir: self.config_dir.clone(),
+            };
+            render.exec(fg, repository).await?;
+        }
+        let config = self.load_config(repository, &fg.config_dir, &fg.config_file).await?;
+        let up = Up {};
+        up.exec(None, repository).await?;
+        let repository_name = repository.to_owned();
+        config.write_pid_file("fireguard", process::id()).await?;
+        info!("Fireguard daemon started successfully");
+        self.handle_signals(config, repository_name).await?;
+        Ok(())
+    }
+}
+
+/// Stop Fireguard daemon
+#[derive(Clap, Debug)]
+pub struct Stop {}
+
+impl Command for Stop {}
+impl Stop {
+    pub async fn exec(&self, fg: &Fireguard, repository: &str) -> Result<()> {
+        info!("Stopping foreground Fireguard daemon");
+        let config = self.load_config(repository, &fg.config_dir, &fg.config_file).await?;
+        let pid = fs::read_to_string(&config.pid_file("fireguard")).await?.parse::<i32>()?;
+        debug!("Sending SIGTERM to PID {}", pid);
+        signal::kill(Pid::from_raw(pid), signal::SIGTERM)?;
+        Ok(())
+    }
+}
+
+/// Stop Fireguard daemon
+#[derive(Clap, Debug)]
+pub struct Status {}
+
+impl Command for Status {}
+impl Status {
+    pub async fn exec(&self, fg: &Fireguard, repository: &str) -> Result<()> {
+        let config = self.load_config(repository, &fg.config_dir, &fg.config_file).await?;
+        match fs::read_to_string(config.pid_file("fireguard")).await {
+            Ok(pid) => {
+                info!("Fireguard daemon is running with PID {}", pid);
+                let peer_list = List {};
+                peer_list
+                    .exec(fg, config, repository)
+                    .await
+                    .unwrap_or_else(|_| error!("Unable to read {} peer list", repository));
+                let status = WgStatus {};
+                status
+                    .exec(None, repository)
+                    .await
+                    .unwrap_or_else(|_| error!("Unable to get {} Wireguard status", repository));
+                Ok(())
+            }
+            Err(_) => {
+                bail!("Fireguard PID not found, did you start Fireguard with `daemon serve` command?");
+            }
+        }
     }
 }

--- a/src/cmd/docker.rs
+++ b/src/cmd/docker.rs
@@ -1,8 +1,7 @@
 use clap::Clap;
 use color_eyre::eyre::{bail, Result};
 
-use crate::cmd::Fireguard;
-use crate::cmd::{Dns, Peer, Repo, Wg};
+use crate::cmd::{Daemon, Dns, Fireguard, Peer, Repo, Wg};
 use crate::shell::Shell;
 
 /// Docker - Docker command management
@@ -32,6 +31,8 @@ pub enum Action {
     Wg(Wg),
     /// DNS management under Docker
     Dns(Dns),
+    /// Daemon management
+    Daemon(Daemon),
 }
 
 impl Docker {
@@ -46,16 +47,10 @@ impl Docker {
             docker_cmd += &format!(" -v {}", volumes.join("-v "));
         } else {
             docker_cmd += " -v /etc/fireguard:/etc/fireguard";
-        } 
-        docker_cmd += &format!(" {} fireguard {}", self.docker_image(), args); 
+        }
+        docker_cmd += &format!(" {} fireguard {}", self.docker_image(), args);
         info!("Running command `{}` inside Docker container {}", args, self.docker_image());
-        let result = Shell::exec(
-            "docker",
-            &docker_cmd,
-            None,
-            false,
-        )
-        .await;
+        let result = Shell::exec("docker", &docker_cmd, None, false).await;
         if result.success() {
             debug!("Command {} succeeded inside Docker container {}", args, self.docker_image());
             Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,11 +56,22 @@ impl Config {
         self.peers.values().into_iter().map(|v| v.address.clone()).collect::<Vec<String>>()
     }
 
+    pub fn pid_file(&self, daemon: &str) -> PathBuf {
+        Path::new(&self.config_dir).join(&format!("{}.pid", daemon))
+    }
+
     pub async fn write_pid_file(&self, daemon: &str, pid: u32) -> Result<()> {
-        let path = Path::new(&self.config_dir).join(&format!("{}.pid", daemon));
+        let path = self.pid_file(daemon);
         let mut file = fs::File::create(&path).await?;
         file.write(&format!("{}", pid).as_bytes()).await?;
         info!("Written PID {} for {} on file for {}", pid, daemon, path.display());
+        Ok(())
+    }
+
+    pub async fn remove_pid_file(&self, daemon: &str) -> Result<()> {
+        let path = self.pid_file(daemon);
+        fs::remove_file(&path).await?;
+        info!("PID file {} removed from disk", path.display());
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate futures_util;
 extern crate ipnet;
 #[macro_use]
 extern crate log;
+extern crate nix;
 extern crate parking_lot;
 extern crate pretty_env_logger;
 extern crate rand;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,49 @@
 use log::LevelFilter;
 
+use color_eyre::eyre::{bail, Result};
+
+use crate::shell::Shell;
+
+pub const APT_PACKAGES: &str = "bc ca-certificates dnsmasq iptables wireguard wireguard-dkms wireguard-tools";
+
 pub fn setup_logging(debug: bool) {
     let mut builder = pretty_env_logger::formatted_timed_builder();
     builder.format_timestamp_secs();
     let level = if debug { LevelFilter::Debug } else { LevelFilter::Info };
     builder.filter_level(level);
     builder.init()
+}
+
+pub async fn install_wireguard_kernel_module() -> Result<()> {
+    let kver_cmd = Shell::exec("uname", "-r", None, false).await;
+    let kver = kver_cmd.stdout().trim();
+    let modprobe_cmd = Shell::exec("modprobe", "wireguard", None, false).await;
+    if modprobe_cmd.success() {
+        info!("Wireguard module already installed for kernel version {}", kver);
+        Ok(())
+    } else {
+        let armv7 = Shell::exec("uname", "-r |grep -q 'v7+'", None, true).await;
+        let armv7l = Shell::exec("uname", "-r |grep -q 'v7l+'", None, true).await;
+        let armv8 = Shell::exec("uname", "-r |grep -q 'v8+'", None, true).await;
+        let package: String;
+        if armv7.success() || armv7l.success() || armv8.success() {
+            package = "raspberrypi-kernel-headers".to_string();
+            info!("Detected Rasbian installation, installing kernel headers {} and Wireguard module", package);
+        } else {
+            package = format!("linux-headers-{}", kver);
+            info!(
+                "Detected generic debian based installation, installing kernel headers {} and Wireguard module",
+                package
+            );
+        }
+        info!("Wireguard module not found, building it for kernel version {}", kver);
+        Shell::exec("apt-get", "update", None, false).await;
+        let apt_cmd = Shell::exec("apt-get", &format!("-y install {} {}", package, APT_PACKAGES,), None, false).await;
+        if apt_cmd.success() {
+            warn!("Wireguard kernel module installed successfully for version {}", kver);
+            Ok(())
+        } else {
+            bail!("Unable to find kernel header for kernel version {}, Wireguard module not installed")
+        }
+    }
 }


### PR DESCRIPTION
* 161eb90 Update changelog for v0.0.5
* fd05d6a Release version 0.0.5
* 39d3c99 Add docker multi arch build directives to Makefile
* 42ffe8e Fix #12. Move package installation to Fireguard startup to let it happen on the actual host and not during docker buildx, where apt causes many failures inside docker qemu.