### PR TITLE
Add basic IpPool tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,16 @@ raspberry_aarch64_debug:
 raspberry_aarch64:
 	cargo build --release --target=aarch64-unknown-linux-gnu 
 
+test:
+	cargo test
+
+coverage:
+ifeq ("", $(shell which cargo-tarpaulin))
+$(error "No cargo tarpaulin found in $(PATH), please install with cargo install cargo-tarpaulin if you want to run coverage")
+endif
+	cargo tarpaulin
+
+
 tag:
 	$(eval VERSION=$(shell target/debug/fireguard --version | sed 's#fireguard ##g'))
 	$(eval CHANGELOG=$(shell git log $(shell git describe --tags --abbrev=0)..HEAD --oneline))

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -53,3 +53,52 @@ impl IpPool {
         Ok(free_ip)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn test_creation_with_expected_values() {
+        let mut data = Vec::new();
+        data.push((
+            "192.168.1.0/24",
+            vec!["192.168.1.1/32".to_string(), "192.168.1.234/32".to_string(), "192.168.1.2/32".to_string()],
+            251,
+            3,
+        ));
+        data.push(("10.0.0.0/16", vec![], 65534, 0));
+
+        for (subnet, peers, free_len, used_len) in data {
+            let pool = IpPool::new(subnet, peers.to_vec()).unwrap();
+            assert_eq!(pool.free_list.len(), free_len);
+            assert_eq!(pool.used_list.len(), used_len);
+            for peer in peers {
+                assert!(!pool.free_list.contains(&Ipv4Addr::from_str(&peer.split_once("/").unwrap().0).unwrap()));
+            }
+        }
+    }
+
+    #[test]
+    fn test_generate_ip_is_in_subnet() {
+        let subnets = vec!["10.0.0.0/8", "10.10.0.0/16", "192.168.1.0/24", "192.168.1.0/31"];
+        for subnet in subnets {
+            let mut pool = IpPool::new(subnet, vec![]).unwrap();
+            let ip = pool.ip().unwrap();
+            let this: Ipv4Net = subnet.parse().unwrap();
+            assert!(this.contains(&ip));
+        }
+    }
+
+    #[test]
+    fn test_full_pool_bails() {
+        let mut pool =
+            IpPool::new("192.168.1.0/31", vec!["192.168.1.0/32".to_string(), "192.168.1.1/32".to_string()]).unwrap();
+        let err = pool.ip();
+        assert!(err.is_err());
+        assert_eq!(err.err().unwrap().to_string(), "Unable to find a free IPv4 in the pool");
+    }
+}

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -77,7 +77,8 @@ mod tests {
             assert_eq!(pool.free_list.len(), free_len);
             assert_eq!(pool.used_list.len(), used_len);
             for peer in peers {
-                assert!(!pool.free_list.contains(&Ipv4Addr::from_str(&peer.split_once("/").unwrap().0).unwrap()));
+                let ipaddr_peer = &Ipv4Addr::from_str(&(peer.splitn(2, "/").collect::<Vec<&str>>())[0]).unwrap();
+                assert!(!pool.free_list.contains(ipaddr_peer));
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(str_split_once)]
+
 extern crate async_trait;
 extern crate chrono;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(str_split_once)]
-
 extern crate async_trait;
 extern crate chrono;
 #[macro_use]


### PR DESCRIPTION
This change adds some basic IpPool tests and a make target to run [tarpaulin](https://github.com/xd009642/tarpaulin) to get coverage. Not necessarily portable as it uses the `which` command to check for the tarpaulin executable.