### PR TITLE
Implemented ipv4.forward (for docker)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,11 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
-RUN mkdir -p /etc/fireguard /etc/wireguard
+RUN mkdir -p /etc/fireguard /etc/wireguard && \
+    apt-get update && \
+    apt-get install -y git && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY ./$TARGETPLATFORM/fireguard /usr/bin/fireguard
 

--- a/src/cmd/docker.rs
+++ b/src/cmd/docker.rs
@@ -4,6 +4,7 @@ use color_eyre::eyre::{bail, Result};
 use crate::cmd::{Daemon, Dns, Fireguard, Peer, Repo, Wg};
 use crate::shell::Shell;
 use crate::utils::install_wireguard_kernel_module;
+use crate::utils::enforce_host_config;
 
 /// Docker - Docker command management
 #[derive(Clap, Debug)]
@@ -47,6 +48,7 @@ impl Docker {
 
     pub async fn exec(&self, fg: &Fireguard) -> Result<()> {
         install_wireguard_kernel_module().await?;
+        enforce_host_config().await?;
         let args = fg.args.join(" ");
         let mut docker_cmd = format!("run -t --rm --privileged --net=host");
         // TODO: document how to use volumes, especially if there are plans for custom paths.


### PR DESCRIPTION
This change enables net.ip4.ip_forward at startup (when used as fireguard docker)

It should resolve #6 as of now, we'll then see how to change it to be Darwin compatible (ifneedbe)